### PR TITLE
Update to LDtk 0.9.3

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -135,7 +135,7 @@ fn main() {
         .unwrap();
 
     #[cfg(not(feature = "download-schema"))]
-    let version = std::env::var("LDTK_VERSION").unwrap_or("v0.8.1".into());
+    let version = std::env::var("LDTK_VERSION").unwrap_or("v0.9.3".into());
     #[cfg(not(feature = "download-schema"))]
     let schema: JsonSchema = serde_json::from_reader(
         std::fs::OpenOptions::new()

--- a/examples/full-features.ldtk
+++ b/examples/full-features.ldtk
@@ -5,10 +5,10 @@
 		"doc": "https://ldtk.io/json",
 		"schema": "https://ldtk.io/files/JSON_SCHEMA.json",
 		"appAuthor": "Sebastien 'deepnight' Benard",
-		"appVersion": "0.8.1",
+		"appVersion": "0.9.3",
 		"url": "https://ldtk.io"
 	},
-	"jsonVersion": "0.8.1",
+	"jsonVersion": "0.9.3",
 	"nextUid": 45,
 	"worldLayout": "LinearVertical",
 	"worldGridWidth": 256,
@@ -23,10 +23,11 @@
 	"minifyJson": false,
 	"externalLevels": false,
 	"exportTiled": false,
-	"exportPng": false,
+	"imageExportMode": "None",
 	"pngFilePattern": null,
 	"backupOnSave": false,
 	"backupLimit": 10,
+	"levelNamePattern": "Level_%idx",
 	"flags": ["DiscardPreCsvIntGrid"],
 	"defs": { "layers": [
 		{
@@ -80,35 +81,30 @@
 			"excludedTags": [],
 			"intGridValues": [{ "value": 1, "identifier": null, "color": "#000000" }],
 			"autoTilesetDefUid": 2,
-			"autoRuleGroups": [{
-				"uid": 27,
-				"name": "Test",
-				"active": true,
-				"collapsed": false,
-				"rules": [
-					{
-						"uid": 28,
-						"active": true,
-						"size": 1,
-						"tileIds": [180],
-						"chance": 1,
-						"breakOnMatch": true,
-						"pattern": [3],
-						"flipX": false,
-						"flipY": false,
-						"xModulo": 1,
-						"yModulo": 1,
-						"checker": "None",
-						"tileMode": "Single",
-						"pivotX": 0,
-						"pivotY": 0,
-						"perlinActive": false,
-						"perlinSeed": 8580464,
-						"perlinScale": 0.2,
-						"perlinOctaves": 2
-					}
-				]
-			}],
+			"autoRuleGroups": [{ "uid": 27, "name": "Test", "active": true, "collapsed": false, "isOptional": false, "rules": [
+				{
+					"uid": 28,
+					"active": true,
+					"size": 1,
+					"tileIds": [180],
+					"chance": 1,
+					"breakOnMatch": true,
+					"pattern": [3],
+					"flipX": false,
+					"flipY": false,
+					"xModulo": 1,
+					"yModulo": 1,
+					"checker": "None",
+					"tileMode": "Single",
+					"pivotX": 0,
+					"pivotY": 0,
+					"outOfBoundsValue": null,
+					"perlinActive": false,
+					"perlinSeed": 8580464,
+					"perlinScale": 0.2,
+					"perlinOctaves": 2
+				}
+			] }],
 			"autoSourceLayerDefUid": 1,
 			"tilesetDefUid": null,
 			"tilePivotX": 0,
@@ -150,119 +146,118 @@
 			"excludedTags": [],
 			"intGridValues": [{ "value": 1, "identifier": "walls", "color": "#D19E4D" }],
 			"autoTilesetDefUid": 2,
-			"autoRuleGroups": [{
-				"uid": 4,
-				"name": "walls",
-				"active": true,
-				"collapsed": false,
-				"rules": [
-					{
-						"uid": 8,
-						"active": true,
-						"size": 3,
-						"tileIds": [104,105],
-						"chance": 1,
-						"breakOnMatch": true,
-						"pattern": [0,0,0,0,1,1,0,-1,-1],
-						"flipX": false,
-						"flipY": false,
-						"xModulo": 2,
-						"yModulo": 1,
-						"checker": "None",
-						"tileMode": "Stamp",
-						"pivotX": 0,
-						"pivotY": 0,
-						"perlinActive": false,
-						"perlinSeed": 3086357,
-						"perlinScale": 0.2,
-						"perlinOctaves": 2
-					},
-					{
-						"uid": 9,
-						"active": true,
-						"size": 3,
-						"tileIds": [104,105],
-						"chance": 1,
-						"breakOnMatch": true,
-						"pattern": [0,-1,-1,0,1,1,0,0,0],
-						"flipX": false,
-						"flipY": false,
-						"xModulo": 2,
-						"yModulo": 1,
-						"checker": "None",
-						"tileMode": "Stamp",
-						"pivotX": 0,
-						"pivotY": 0,
-						"perlinActive": false,
-						"perlinSeed": 3086357,
-						"perlinScale": 0.2,
-						"perlinOctaves": 2
-					},
-					{
-						"uid": 6,
-						"active": true,
-						"size": 5,
-						"tileIds": [8,28,9,29],
-						"chance": 1,
-						"breakOnMatch": true,
-						"pattern": [0,0,0,0,0,0,0,1,1,0,0,0,1,1,0,0,0,1,1,0,0,0,1,1,0],
-						"flipX": false,
-						"flipY": false,
-						"xModulo": 2,
-						"yModulo": 2,
-						"checker": "None",
-						"tileMode": "Stamp",
-						"pivotX": 0,
-						"pivotY": 0,
-						"perlinActive": false,
-						"perlinSeed": 4215655,
-						"perlinScale": 0.2,
-						"perlinOctaves": 2
-					},
-					{
-						"uid": 7,
-						"active": true,
-						"size": 3,
-						"tileIds": [164],
-						"chance": 1,
-						"breakOnMatch": true,
-						"pattern": [0,-1,0,-1,1,0,0,0,0],
-						"flipX": true,
-						"flipY": true,
-						"xModulo": 1,
-						"yModulo": 1,
-						"checker": "None",
-						"tileMode": "Single",
-						"pivotX": 0,
-						"pivotY": 0,
-						"perlinActive": false,
-						"perlinSeed": 8557859,
-						"perlinScale": 0.2,
-						"perlinOctaves": 2
-					},
-					{
-						"uid": 5,
-						"active": true,
-						"size": 1,
-						"tileIds": [140],
-						"chance": 1,
-						"breakOnMatch": true,
-						"pattern": [1],
-						"flipX": false,
-						"flipY": false,
-						"xModulo": 1,
-						"yModulo": 1,
-						"checker": "None",
-						"tileMode": "Single",
-						"pivotX": 0,
-						"pivotY": 0,
-						"perlinActive": false,
-						"perlinSeed": 1571824,
-						"perlinScale": 0.2,
-						"perlinOctaves": 2
-					}
-				]
-			}],
+			"autoRuleGroups": [{ "uid": 4, "name": "walls", "active": true, "collapsed": false, "isOptional": false, "rules": [
+				{
+					"uid": 8,
+					"active": true,
+					"size": 3,
+					"tileIds": [104,105],
+					"chance": 1,
+					"breakOnMatch": true,
+					"pattern": [0,0,0,0,1,1,0,-1,-1],
+					"flipX": false,
+					"flipY": false,
+					"xModulo": 2,
+					"yModulo": 1,
+					"checker": "None",
+					"tileMode": "Stamp",
+					"pivotX": 0,
+					"pivotY": 0,
+					"outOfBoundsValue": null,
+					"perlinActive": false,
+					"perlinSeed": 3086357,
+					"perlinScale": 0.2,
+					"perlinOctaves": 2
+				},
+				{
+					"uid": 9,
+					"active": true,
+					"size": 3,
+					"tileIds": [104,105],
+					"chance": 1,
+					"breakOnMatch": true,
+					"pattern": [0,-1,-1,0,1,1,0,0,0],
+					"flipX": false,
+					"flipY": false,
+					"xModulo": 2,
+					"yModulo": 1,
+					"checker": "None",
+					"tileMode": "Stamp",
+					"pivotX": 0,
+					"pivotY": 0,
+					"outOfBoundsValue": null,
+					"perlinActive": false,
+					"perlinSeed": 3086357,
+					"perlinScale": 0.2,
+					"perlinOctaves": 2
+				},
+				{
+					"uid": 6,
+					"active": true,
+					"size": 5,
+					"tileIds": [8,28,9,29],
+					"chance": 1,
+					"breakOnMatch": true,
+					"pattern": [0,0,0,0,0,0,0,1,1,0,0,0,1,1,0,0,0,1,1,0,0,0,1,1,0],
+					"flipX": false,
+					"flipY": false,
+					"xModulo": 2,
+					"yModulo": 2,
+					"checker": "None",
+					"tileMode": "Stamp",
+					"pivotX": 0,
+					"pivotY": 0,
+					"outOfBoundsValue": null,
+					"perlinActive": false,
+					"perlinSeed": 4215655,
+					"perlinScale": 0.2,
+					"perlinOctaves": 2
+				},
+				{
+					"uid": 7,
+					"active": true,
+					"size": 3,
+					"tileIds": [164],
+					"chance": 1,
+					"breakOnMatch": true,
+					"pattern": [0,-1,0,-1,1,0,0,0,0],
+					"flipX": true,
+					"flipY": true,
+					"xModulo": 1,
+					"yModulo": 1,
+					"checker": "None",
+					"tileMode": "Single",
+					"pivotX": 0,
+					"pivotY": 0,
+					"outOfBoundsValue": null,
+					"perlinActive": false,
+					"perlinSeed": 8557859,
+					"perlinScale": 0.2,
+					"perlinOctaves": 2
+				},
+				{
+					"uid": 5,
+					"active": true,
+					"size": 1,
+					"tileIds": [140],
+					"chance": 1,
+					"breakOnMatch": true,
+					"pattern": [1],
+					"flipX": false,
+					"flipY": false,
+					"xModulo": 1,
+					"yModulo": 1,
+					"checker": "None",
+					"tileMode": "Single",
+					"pivotX": 0,
+					"pivotY": 0,
+					"outOfBoundsValue": null,
+					"perlinActive": false,
+					"perlinSeed": 1571824,
+					"perlinScale": 0.2,
+					"perlinOctaves": 2
+				}
+			] }],
 			"autoSourceLayerDefUid": null,
 			"tilesetDefUid": null,
 			"tilePivotX": 0,
@@ -330,7 +325,7 @@
 					"regex": null,
 					"acceptFileTypes": null,
 					"defaultOverride": null,
-					"textLangageMode": null
+					"textLanguageMode": null
 				},
 				{
 					"identifier": "Float",
@@ -350,7 +345,7 @@
 					"regex": null,
 					"acceptFileTypes": null,
 					"defaultOverride": null,
-					"textLangageMode": null
+					"textLanguageMode": null
 				},
 				{
 					"identifier": "Boolean",
@@ -370,7 +365,7 @@
 					"regex": null,
 					"acceptFileTypes": null,
 					"defaultOverride": null,
-					"textLangageMode": null
+					"textLanguageMode": null
 				},
 				{
 					"identifier": "String_singleLine",
@@ -390,7 +385,7 @@
 					"regex": null,
 					"acceptFileTypes": null,
 					"defaultOverride": null,
-					"textLangageMode": null
+					"textLanguageMode": null
 				},
 				{
 					"identifier": "String_multiLines",
@@ -410,7 +405,7 @@
 					"regex": null,
 					"acceptFileTypes": null,
 					"defaultOverride": null,
-					"textLangageMode": null
+					"textLanguageMode": null
 				},
 				{
 					"identifier": "Enum",
@@ -430,7 +425,7 @@
 					"regex": null,
 					"acceptFileTypes": null,
 					"defaultOverride": null,
-					"textLangageMode": null
+					"textLanguageMode": null
 				},
 				{
 					"identifier": "Color",
@@ -450,7 +445,7 @@
 					"regex": null,
 					"acceptFileTypes": null,
 					"defaultOverride": { "id": "V_Int", "params": [0] },
-					"textLangageMode": null
+					"textLanguageMode": null
 				},
 				{
 					"identifier": "Point",
@@ -470,7 +465,7 @@
 					"regex": null,
 					"acceptFileTypes": null,
 					"defaultOverride": null,
-					"textLangageMode": null
+					"textLanguageMode": null
 				},
 				{
 					"identifier": "FilePath",
@@ -490,7 +485,7 @@
 					"regex": null,
 					"acceptFileTypes": null,
 					"defaultOverride": null,
-					"textLangageMode": null
+					"textLanguageMode": null
 				},
 				{
 					"identifier": "Array_Integer",
@@ -510,7 +505,7 @@
 					"regex": null,
 					"acceptFileTypes": null,
 					"defaultOverride": null,
-					"textLangageMode": null
+					"textLanguageMode": null
 				},
 				{
 					"identifier": "Array_Enum",
@@ -530,7 +525,7 @@
 					"regex": null,
 					"acceptFileTypes": null,
 					"defaultOverride": null,
-					"textLangageMode": null
+					"textLanguageMode": null
 				},
 				{
 					"identifier": "Array_points",
@@ -550,7 +545,7 @@
 					"regex": null,
 					"acceptFileTypes": null,
 					"defaultOverride": null,
-					"textLangageMode": null
+					"textLanguageMode": null
 				},
 				{
 					"identifier": "Array_multilines",
@@ -570,7 +565,7 @@
 					"regex": null,
 					"acceptFileTypes": null,
 					"defaultOverride": null,
-					"textLangageMode": "LangXml"
+					"textLanguageMode": "LangXml"
 				}
 			]
 		},
@@ -616,7 +611,7 @@
 					"regex": null,
 					"acceptFileTypes": null,
 					"defaultOverride": null,
-					"textLangageMode": null
+					"textLanguageMode": null
 				},
 				{
 					"identifier": "color",
@@ -636,7 +631,7 @@
 					"regex": null,
 					"acceptFileTypes": null,
 					"defaultOverride": { "id": "V_Int", "params": [8361387] },
-					"textLangageMode": null
+					"textLanguageMode": null
 				}
 			]
 		},
@@ -682,7 +677,7 @@
 					"regex": null,
 					"acceptFileTypes": null,
 					"defaultOverride": null,
-					"textLangageMode": null
+					"textLanguageMode": null
 				},
 				{
 					"identifier": "Integer",
@@ -702,7 +697,7 @@
 					"regex": null,
 					"acceptFileTypes": null,
 					"defaultOverride": null,
-					"textLangageMode": null
+					"textLanguageMode": null
 				}
 			]
 		},
@@ -748,7 +743,7 @@
 					"regex": null,
 					"acceptFileTypes": null,
 					"defaultOverride": null,
-					"textLangageMode": null
+					"textLanguageMode": null
 				},
 				{
 					"identifier": "text",
@@ -768,12 +763,14 @@
 					"regex": null,
 					"acceptFileTypes": null,
 					"defaultOverride": null,
-					"textLangageMode": null
+					"textLanguageMode": null
 				}
 			]
 		}
 	], "tilesets": [
 		{
+			"__cWid": 20,
+			"__cHei": 14,
 			"identifier": "Inca_front_by_Kronbits_extended",
 			"uid": 2,
 			"relPath": "atlas/Inca_front_by_Kronbits-extended.png",
@@ -782,6 +779,9 @@
 			"tileGridSize": 16,
 			"spacing": 0,
 			"padding": 0,
+			"tagsSourceEnumUid": null,
+			"enumTags": [],
+			"customData": [],
 			"savedSelections": [
 				{ "ids": [241,261,242,262], "mode": "Stamp" },
 				{ "ids": [6,26,7,27], "mode": "Stamp" },
@@ -791,12 +791,11 @@
 				{ "ids": [46,66,47,67], "mode": "Stamp" },
 				{ "ids": [88,89], "mode": "Stamp" }
 			],
-			"cachedPixelData": {
-				"opaqueTiles": "1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111110011111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
-				"averageColors": "f965f964fa65f965f854f854fa65f964fa64f964fa64fa64fa64f964f088f088f088f088f088f088f854f854f854f854f954f854f854f844f954f854f954fa64fa64f954f088f088f088f088f088f088f965f964f965f964f965f954f965f954fa65f965fa54fa64fa64f954f088f088f088f088f088f088f744f744f854f844f854f854f634f533f644f633f954f954f954f854f088f088f088f088f088f088f954f954f964f854f964f954f964f854f964f85430001000f088f088f088f088f088f088f088f088f854f754f964f964f954f854f954f854f854f854f088f088f088f088f088f088f088f088f088f088f855f854f965f964f965f964f965f964f965f964f088f088f088f088f088f088f088f088f088f088f854f854f744f854f954f954f854f965f964f954f088f088f088f088f088f088f088f088f088f088f854f854f854f854f954f964f954f965f854f954f088f088f088f088f088f088f088f088f088f088f854f854f964f855f854f854f954f854f854f964f088f088f088f088f088f088f088f088f088f088f965f854f744f854f643f088f088f088f088f088f088f088f088f088f088f088f088f088f088f088f854f643f643f754f754f088f088f088f088f088f088f088f088f088f088f088f088f088f088f088fa65f965f954f744f566f088f088f088f088f088f088f088f088f088f088f088f088f088f088f088f965f965f954f744f088f088f088f088f088f088f088f088f088f088f088f088f088f088f088f088"
-			}
+			"cachedPixelData": null
 		},
 		{
+			"__cWid": 16,
+			"__cHei": 128,
 			"identifier": "_Soul_s_RPG_Graphics_Icons",
 			"uid": 31,
 			"relPath": "atlas/RPG Graphics Icons by 7Soul's.png",
@@ -805,17 +804,17 @@
 			"tileGridSize": 16,
 			"spacing": 0,
 			"padding": 0,
+			"tagsSourceEnumUid": null,
+			"enumTags": [],
+			"customData": [],
 			"savedSelections": [],
-			"cachedPixelData": {
-				"opaqueTiles": "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000100000000100000000100000000000000000000111000000001111101100001100110000000000000010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000100000000100000000100000000000000000000111000000001111101100001100110000000000000010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
-				"averageColors": "985498548854655587537963763386559b639b739b9496939497969b977a9b8a9a63966597779bbb676667666766666666666667666767676666666666666777697769876a9767876798678a688969896987677768886999788a9b765a968877799987668765a978b876a87879ab7987ba98b953c843b854a854b853b999b888b888c975ba65c976b888b852c763b888b744b666a78ad877c777c573c545c867a942aa51a972a471a175a48aa55aaa69a843a344a566a999ba65ba75ba85b785b786b78ab87aba79b975b776b877baa9ba53ba62ba72b772b685b779b768ba68b954b754b865ba98c877c977c987c787c787c789c778c979c877c777c788c999b943ba51b962b471b175b47ab54aba59b743b344b566b999b966c976c986c786c687c789c77ac979c877c677c777c999a953aa53a963a773a764a778a858aa57a953a754a865a9876843a842a843a854a8559843a999a888a999ab97ab75a975ba65aaaab765a568a868a944aa54a964a674a575a568a658aa59a854a555a666a9994ba9886497325a87569b586587436a635a983a77798b74557b734864895676948baa974399525666688869658b6597823a9847847a9c78337c738a7583887b648aaa689978968aa89a435842a59b5a85aa43697577777ca776667a7659975a97799978887997898a9b7a6693ab938b97a56a976588888ca8977877775aaa5a978a5369929a618a768a826b82873394818c979bb79d978b866ba68b9578327a639b968a466b8888328953758a7a74ca748a75858b68aa8b878c8877947c97b766bc9389547ca8859b6965997598539a44a97687547ca8886468538b96a96496326a62695378539657956878548aaa7c8478828b6a89539a869a9a9b86aa87ba6297437692a692865385485684aa88cb9888539853995398549977774399889889988899769b7598649a5398899866945697599a429b629a7295829385936b955a9a699953945596679aaa99769a76998697969687978a97799a79997797779888999968438742984287438743985297779777a999ba97ba65a864895385757853aa75a33495587545777667468a7568548854995299529962986297639756985599559853974298549975a766a866a876a676a676a678a667a768a766a666a666a777872389418952836181648149833888488633833384458aaa88228951896284718264825a8448895987438223855589987796bb64a69c8a8c6987bca5b5568abbc8bbbdba5998788868885a988b74696465566877687768876787678767786778687868776667677768888b768c868ca6879686a8879c877b8c8b8a77856688888bba8c98bb757a657ca97c983ca969896a746b735a868666b455744576777666366768566666666657678aaab77876777aaa7aaa3aaa6a976888688859988cb9ba857a857cb97ca83ca9699a6ba76ba85aaa8888b677766679997888399968796888688859998a87ba6579647b977a873a876885698769877a887a987ba978987899789b788b7b8b7988788978897aab8a428b718b9286938286858c865a8b6a8864844586668aaa69326a616b8265826185647b65596a6a6853634465666aaa6a426b616b8265826286648b665a6b6a6853644566666aaaaa99aa99aaa9a8a9a8aaa89ba99baa9aaaa9a8999aaa9aaa99aa99ab99ab9aab9aaa9aaa99aa9aaaa9aa9abb99aa69aaabaaaaa9abb9a9a9a9bba9aba9abaabbabaaaaaaa99aaaaaabbba9ab59aa8a998a998aa9a9aa88a988aa889b899b8a9a8a998899899a8abb89aa79ab47998a998a998aa988a988aa889b899b8a9a8a999aaa8899899a8abb89aa59aa9a999a999aa998a998ab9a99989b999b9a9a9aa9989999aa9abb98aa79ab9caa9aa99baa9cba99ba99bb99ac9aac9bab9baa99aa9aaa99a99ccc9abb59aaaaaaaaaaaaaaa9aaa9aba9ab999b99aaaaaaaaaaa9aaaaaaaabba9aa59aa7aaa7aaa7aaa999b79aa79aa79ab79ab7aaa7aaa799a79aa7aab79aa99ab389a6aaa6aaa6aaa69aa69aa69ab69ab6aaa6aaa9a9a69aa6aaa6abb69aa389a9aaa999999aa9abb99aa89ab8a9989998aa988a988aa889a899a8a9a8999889989998aaa899a589a8aaa8aaa8aaa89aa89ab89ab89ab8aaa8aaa899a89aa8abb89aa589a8a9989998aa988a988aa889a899b8a9a89998899899a8aab899a589a7aaa7aaa7aaa79aa79aa79ab79ab7aaa7aaa79aa7aaa7abb79aa389a9baa9aa99ba999a999ab99ab99ab9b9a9aaa999a99aa9bbc99ab58aa9aaacb76cb85cb96ca85ca86ca87cb87cb87cb86ca86cb86cb87ab76ac85ab86aa96a986aa89aa78ac88aa76a976aa87ab98ab75ab75ab95a995a886a989a979ab88aa76a976aa87ab999b879c879c979b979b979b989b879c879b879b879b879b975c755c845ca559a557a8599b597a5c9a5b7658765a995cbabb75bb85bb95b985b996b98ab979bb89ba75b876b986bba9ba77bb87bb97b897b898b89bb88abb8ab988b788b888baaab966ba76ba86b686b687b68ab779ba79b776b666b777b999aca9ada9adb9acb9acb9acb9aca9ada9aca9aca9aca9acb9acccacccacccacccacccacccacccacccacccacccacccaccccb76cc75cc86ca85ca86ca88ca78cc78cb76ca76ca76cb98c644c754c764c464c465c457c447c756c544c444c455c677bb76bb75bb85b985b986b989b978bb88ba75b976ba76bb98db64dc74db94d794d597d79cd77bdc8ada65d666d877d998db65dc75db85d795d697d79bd87bdb8ad976d666d877d998db75dc85db86da95d997da99da88dc88db86d976da87db97cb86cca88c97ab97bb868db98dcabdbaadb9adb9ab87cc867b97c998bc97a998bbaa8ccc8dddbdddacccacccaa86ab97a667a8888998998999889a976789b99589438a969a889a988989999997739878787778777877777777777778777877777777777777777777988898889888988898889889988898889888977798889888a877a887a887a787a777a789a778a878a877a677a777a88887779899899969996888a7776777988898887997799779977997799779987998799779977987799779979a979a979a979a979a979a989a989a979a9799979a979a97aa86aa96aa97a996a996a998a997aa87aa96a986a986aa9789979aa98baa6aa96a99aa9669979a979a98ca64c965ca8798889899e999b964ba88bbbbbc96abbbab9abb86a999ab97bbbbca77cb87cb97c897c798c89bc88acb8aca87c788c888cabbbb88bc98bca8b9a8b8a9b9acb99bbc9bba98b889b999bbbbb9aaaaaac7799c96ab73fa648b74939983999188b688889bbabdc8abf479789a96899569b479b86486437853a642f17592968175829796936896b3717472b7a4b6929886e643bbbb9abbb9ac99aa9c8a9d9bbc8abc8abddcfca8f975fa989879c3388337a4386a43a9338933a868f848f848f869f637f757a769f99bf426aa8b9a77879b998af779f7768a75c89bf955f259ca87aaaacba8a78bd999c9a98b74e245968a7789875386877764d582f56adb8a8a978559c9339a58a758aaa7aaa79aa79ba78ba7aaa7aaa7aaa7aaa78ba78ba77ca3aca39cb39cb36cb3a89aa8aaa8ab98ab88aba8aa989aa8aba8aa88ab88ab769ca6ac97ac97ac67acacbbaccc8baa8999aaaa7a998baa7a998cba9bba7bbaabbaabba8bba9aa9bbbaaa99aaaa99999888baaa88889a9989888998aaa98aa9aaa8aaa98a98a998caa99cccab998a9a9a889b69ba767ba5bbbb8ba98a95caa9cc87aa82abab8655b99a99bca7acf68b879c9b528b529a32ba668683b7a4c683f4647a9699729767b963ba8689657974a964fa759b8789758b97986c698ab64a775abb85ba739978e562bbba9bbabba89aa999bc9acdb9bcb8bdbdcdfbacf869f99a9887c4558444a455658ba47b847ba469f58bf57bf68bf469f567a777fa89f975aba998898a969897f867f7798965ca98f79cfa43ca98aaa9c99aaa8ad693c9ab87ace94394627987897589877866d964f964d8ac8a8a8455c47b969ba679497679654789758758659a9648764776498648544889387746654864479359ab4aa8577548654a757a989b8778aba6987987ba95787676667a97785379ab99887888687698779a889988a89989779b97a966a88865699a74aa87a786889878649556aa8678769a65787772868864a9867888733579867932768a7964668a897765627a76797787778a87986678756985997667768a96778768439448768985598876aa76878aa4868865aa868865875489768853888789879987a9779785998a9a87999997788987a9679865a78a9a558a98a8889675b87999758a9949987b8648ab959849879a96487645554a98484349ab5988598858876889687958885856598778885877598749765799587757855899467958676a877a995a9849994854787a6b977a999b9879bc97a97a99bba7798776667ba979547abb79878ba9778869777879799989658a97aa7768768965679bc4877866a985676566546a9869536999887758776a757877877786777a9878676777885556877a76753597568976687677787732876569766987767577788a85a98739876a76389aa497587689853876366639973854388968774877588759875877677758886988598759777a66578aa78868679a87586657775a965965589a5899487678696454767a678658657a96763558675b996a866742986966676aaa698888658a977999aa87789bb7888977ba86766673337a97782279ac888878998888a999877789989a779ba978996aaaab9779bba7a97a98bba7698865556ba969436abb59997bbb7b99789a69a8689a7a99788878877a997a998999889a7b8779889a9987778ba87a65687658765a998aaa977a7ba839766a75368b867649659986386536773986385338994865478847897863578957796755486858895a865b994878567498686a85599a49799744999900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
-			}
+			"cachedPixelData": null
 		}
 	], "enums": [{ "identifier": "SomeEnum", "uid": 21, "values": [
-		{ "id": "A", "tileId": 60, "__tileSrcRect": [192,48,16,16] },
-		{ "id": "B", "tileId": 1145, "__tileSrcRect": [144,1136,16,16] },
-		{ "id": "C", "tileId": 678, "__tileSrcRect": [96,672,16,16] },
-		{ "id": "D", "tileId": 1723, "__tileSrcRect": [176,1712,16,16] }
+		{ "id": "A", "tileId": 60, "color": -1, "__tileSrcRect": [192,48,16,16] },
+		{ "id": "B", "tileId": 1145, "color": -1, "__tileSrcRect": [144,1136,16,16] },
+		{ "id": "C", "tileId": 678, "color": -1, "__tileSrcRect": [96,672,16,16] },
+		{ "id": "D", "tileId": 1723, "color": -1, "__tileSrcRect": [176,1712,16,16] }
 	], "iconTilesetUid": 31, "externalRelPath": null, "externalFileChecksum": null }], "externalEnums": [], "levelFields": [
 		{
 			"identifier": "desc",
@@ -835,7 +834,7 @@
 			"regex": null,
 			"acceptFileTypes": null,
 			"defaultOverride": null,
-			"textLangageMode": null
+			"textLanguageMode": null
 		}
 	] },
 	"levels": [
@@ -848,6 +847,7 @@
 			"pxHei": 568,
 			"__bgColor": "#6E6F8B",
 			"bgColor": null,
+			"useAutoIdentifier": false,
 			"bgRelPath": null,
 			"bgPos": null,
 			"bgPivotX": 0.5,
@@ -883,6 +883,7 @@
 					"pxOffsetX": 0,
 					"pxOffsetY": 0,
 					"visible": true,
+					"optionalRules": [],
 					"intGridCsv": [],
 					"autoLayerTiles": [],
 					"seed": 7679736,
@@ -1257,6 +1258,7 @@
 					"pxOffsetX": 0,
 					"pxOffsetY": 0,
 					"visible": true,
+					"optionalRules": [],
 					"intGridCsv": [
 						0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
 						0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
@@ -1454,6 +1456,7 @@
 					"pxOffsetX": 0,
 					"pxOffsetY": 0,
 					"visible": true,
+					"optionalRules": [],
 					"intGridCsv": [],
 					"autoLayerTiles": [
 						{ "px": [304,112], "src": [0,144], "f": 0, "t": 180, "d": [28,320] },
@@ -1514,6 +1517,7 @@
 					"pxOffsetX": 0,
 					"pxOffsetY": 0,
 					"visible": true,
+					"optionalRules": [],
 					"intGridCsv": [
 						0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
 						0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
@@ -1583,6 +1587,7 @@
 					"pxOffsetX": 0,
 					"pxOffsetY": 0,
 					"visible": true,
+					"optionalRules": [],
 					"intGridCsv": [
 						0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
 						0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
@@ -1705,6 +1710,7 @@
 					"pxOffsetX": 0,
 					"pxOffsetY": 0,
 					"visible": true,
+					"optionalRules": [],
 					"intGridCsv": [],
 					"autoLayerTiles": [],
 					"seed": 1504355,
@@ -1757,6 +1763,7 @@
 			"pxHei": 256,
 			"__bgColor": "#6E6F8B",
 			"bgColor": null,
+			"useAutoIdentifier": false,
 			"bgRelPath": null,
 			"bgPos": null,
 			"bgPivotX": 0.5,
@@ -1781,6 +1788,7 @@
 					"pxOffsetX": 0,
 					"pxOffsetY": 0,
 					"visible": true,
+					"optionalRules": [],
 					"intGridCsv": [],
 					"autoLayerTiles": [],
 					"seed": 8894473,
@@ -1899,6 +1907,7 @@
 					"pxOffsetX": 0,
 					"pxOffsetY": 0,
 					"visible": true,
+					"optionalRules": [],
 					"intGridCsv": [
 						0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
 						0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
@@ -1953,6 +1962,7 @@
 					"pxOffsetX": 0,
 					"pxOffsetY": 0,
 					"visible": true,
+					"optionalRules": [],
 					"intGridCsv": [],
 					"autoLayerTiles": [],
 					"seed": 106526,
@@ -1976,6 +1986,7 @@
 					"pxOffsetX": 0,
 					"pxOffsetY": 0,
 					"visible": true,
+					"optionalRules": [],
 					"intGridCsv": [
 						0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
 						0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
@@ -2008,6 +2019,7 @@
 					"pxOffsetX": 0,
 					"pxOffsetY": 0,
 					"visible": true,
+					"optionalRules": [],
 					"intGridCsv": [
 						0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,1,1,1,1,1,1,1,1,1,1,1,1,1,0,0,1,1,
 						1,1,1,1,1,1,1,1,1,1,1,1,0,0,1,1,1,1,1,1,1,1,1,1,1,1,1,1,0,0,1,1,1,0,0,
@@ -2229,6 +2241,7 @@
 					"pxOffsetX": 0,
 					"pxOffsetY": 0,
 					"visible": true,
+					"optionalRules": [],
 					"intGridCsv": [],
 					"autoLayerTiles": [],
 					"seed": 5395320,
@@ -2248,6 +2261,7 @@
 			"pxHei": 160,
 			"__bgColor": "#6E6F8B",
 			"bgColor": null,
+			"useAutoIdentifier": false,
 			"bgRelPath": null,
 			"bgPos": null,
 			"bgPivotX": 0.5,
@@ -2272,6 +2286,7 @@
 					"pxOffsetX": 0,
 					"pxOffsetY": 0,
 					"visible": true,
+					"optionalRules": [],
 					"intGridCsv": [],
 					"autoLayerTiles": [],
 					"seed": 8894473,
@@ -2295,6 +2310,7 @@
 					"pxOffsetX": 0,
 					"pxOffsetY": 0,
 					"visible": true,
+					"optionalRules": [],
 					"intGridCsv": [
 						0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
 						0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
@@ -2338,6 +2354,7 @@
 					"pxOffsetX": 0,
 					"pxOffsetY": 0,
 					"visible": true,
+					"optionalRules": [],
 					"intGridCsv": [],
 					"autoLayerTiles": [],
 					"seed": 106526,
@@ -2361,6 +2378,7 @@
 					"pxOffsetX": 0,
 					"pxOffsetY": 0,
 					"visible": true,
+					"optionalRules": [],
 					"intGridCsv": [
 						0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,1,1,1,1,1,1,1,0,0,0,0,0,0,0,
 						0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,2,0,0,0,0,
@@ -2390,6 +2408,7 @@
 					"pxOffsetX": 0,
 					"pxOffsetY": 0,
 					"visible": true,
+					"optionalRules": [],
 					"intGridCsv": [
 						0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
 						0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,1,1,1,1,1,1,1,0,0,0,0,0,0,0,0,1,1,
@@ -2472,6 +2491,7 @@
 					"pxOffsetX": 0,
 					"pxOffsetY": 0,
 					"visible": true,
+					"optionalRules": [],
 					"intGridCsv": [],
 					"autoLayerTiles": [],
 					"seed": 5395320,
@@ -2508,11 +2528,12 @@
 			"pxHei": 192,
 			"__bgColor": "#6E6F8B",
 			"bgColor": null,
+			"useAutoIdentifier": false,
 			"bgRelPath": "atlas/Beach by deepnight.png",
 			"bgPos": "Cover",
 			"bgPivotX": 0.5,
 			"bgPivotY": 0.5,
-			"__bgPos": { "topLeftPx": [0,0], "scale": [0.85,0.85], "cropRect": [0,7.058823529411768,320,225.88235294117646] },
+			"__bgPos": null,
 			"externalRelPath": null,
 			"fieldInstances": [{
 				"__identifier": "desc",
@@ -2541,6 +2562,7 @@
 					"pxOffsetX": 0,
 					"pxOffsetY": 0,
 					"visible": true,
+					"optionalRules": [],
 					"intGridCsv": [],
 					"autoLayerTiles": [],
 					"seed": 3655473,
@@ -2564,6 +2586,7 @@
 					"pxOffsetX": 0,
 					"pxOffsetY": 0,
 					"visible": true,
+					"optionalRules": [],
 					"intGridCsv": [
 						0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
 						0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
@@ -2612,6 +2635,7 @@
 					"pxOffsetX": 0,
 					"pxOffsetY": 0,
 					"visible": true,
+					"optionalRules": [],
 					"intGridCsv": [],
 					"autoLayerTiles": [],
 					"seed": 5193927,
@@ -2635,6 +2659,7 @@
 					"pxOffsetX": 0,
 					"pxOffsetY": 0,
 					"visible": true,
+					"optionalRules": [],
 					"intGridCsv": [
 						0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
 						0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
@@ -2665,6 +2690,7 @@
 					"pxOffsetX": 0,
 					"pxOffsetY": 0,
 					"visible": true,
+					"optionalRules": [],
 					"intGridCsv": [
 						0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
 						0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
@@ -2726,6 +2752,7 @@
 					"pxOffsetX": 0,
 					"pxOffsetY": 0,
 					"visible": true,
+					"optionalRules": [],
 					"intGridCsv": [],
 					"autoLayerTiles": [],
 					"seed": 4655507,

--- a/schemas/v0.9.3.json
+++ b/schemas/v0.9.3.json
@@ -1,0 +1,1936 @@
+{
+    "description": "This file is a JSON schema of files created by LDtk level editor (https://ldtk.io).",
+    "title": "LDtk 0.9.3 JSON schema",
+    "$schema": "https://json-schema.org/draft-07/schema#",
+    "$ref": "#/LdtkJsonRoot",
+    "version": "0.9.3",
+    "LdtkJsonRoot": {
+        "description": "This is the root of any Project JSON file. It contains:  - the project settings, - an array of levels, - a group of definitions (that can probably be safely ignored for most users).",
+        "title": "LDtk Json root",
+        "required": [
+            "bgColor",
+            "defs",
+            "externalLevels",
+            "jsonVersion",
+            "levels",
+            "worldGridHeight",
+            "worldGridWidth",
+            "worldLayout",
+            "backupLimit",
+            "backupOnSave",
+            "defaultGridSize",
+            "defaultLevelBgColor",
+            "defaultLevelHeight",
+            "defaultLevelWidth",
+            "defaultPivotX",
+            "defaultPivotY",
+            "exportTiled",
+            "flags",
+            "imageExportMode",
+            "levelNamePattern",
+            "minifyJson",
+            "nextUid"
+        ],
+        "properties": {
+            "backupLimit": {
+                "description": "Number of backup files to keep, if the `backupOnSave` is TRUE",
+                "type": [
+                    "integer"
+                ]
+            },
+            "backupOnSave": {
+                "description": "If TRUE, an extra copy of the project will be created in a sub folder, when saving.",
+                "type": [
+                    "boolean"
+                ]
+            },
+            "worldGridWidth": {
+                "description": "Width of the world grid in pixels.",
+                "type": [
+                    "integer"
+                ]
+            },
+            "defaultLevelBgColor": {
+                "description": "Default background color of levels",
+                "type": [
+                    "string"
+                ]
+            },
+            "bgColor": {
+                "description": "Project background color",
+                "type": [
+                    "string"
+                ]
+            },
+            "nextUid": {
+                "description": "Next Unique integer ID available",
+                "type": [
+                    "integer"
+                ]
+            },
+            "imageExportMode": {
+                "description": "\"Image export\" option when saving project. Possible values: `None`, `OneImagePerLayer`, `OneImagePerLevel`",
+                "enum": [
+                    "None",
+                    "OneImagePerLayer",
+                    "OneImagePerLevel"
+                ]
+            },
+            "defaultPivotY": {
+                "description": "Default Y pivot (0 to 1) for new entities",
+                "type": [
+                    "number"
+                ]
+            },
+            "worldGridHeight": {
+                "description": "Height of the world grid in pixels.",
+                "type": [
+                    "integer"
+                ]
+            },
+            "defaultGridSize": {
+                "description": "Default grid size for new layers",
+                "type": [
+                    "integer"
+                ]
+            },
+            "worldLayout": {
+                "description": "An enum that describes how levels are organized in this project (ie. linearly or in a 2D space). Possible values: `Free`, `GridVania`, `LinearHorizontal`, `LinearVertical`",
+                "enum": [
+                    "Free",
+                    "GridVania",
+                    "LinearHorizontal",
+                    "LinearVertical"
+                ]
+            },
+            "flags": {
+                "description": "An array containing various advanced flags (ie. options or other states). Possible values: `DiscardPreCsvIntGrid`, `IgnoreBackupSuggest`",
+                "items": {
+                    "enum": [
+                        "DiscardPreCsvIntGrid",
+                        "IgnoreBackupSuggest"
+                    ]
+                },
+                "type": [
+                    "array"
+                ]
+            },
+            "levelNamePattern": {
+                "description": "The default naming convention for level identifiers.",
+                "type": [
+                    "string"
+                ]
+            },
+            "exportPng": {
+                "description": "**WARNING**: this deprecated value is no longer exported since version 0.9.3  Replaced by: `imageExportMode`",
+                "type": [
+                    "boolean",
+                    "null"
+                ]
+            },
+            "defaultLevelWidth": {
+                "description": "Default new level width",
+                "type": [
+                    "integer"
+                ]
+            },
+            "pngFilePattern": {
+                "description": "File naming pattern for exported PNGs",
+                "type": [
+                    "string",
+                    "null"
+                ]
+            },
+            "exportTiled": {
+                "description": "If TRUE, a Tiled compatible file will also be generated along with the LDtk JSON file (default is FALSE)",
+                "type": [
+                    "boolean"
+                ]
+            },
+            "defs": {
+                "description": "A structure containing all the definitions of this project",
+                "$ref": "#/otherTypes/Definitions"
+            },
+            "levels": {
+                "description": "All levels. The order of this array is only relevant in `LinearHorizontal` and `linearVertical` world layouts (see `worldLayout` value). Otherwise, you should refer to the `worldX`,`worldY` coordinates of each Level.",
+                "items": {
+                    "$ref": "#/otherTypes/Level"
+                },
+                "type": [
+                    "array"
+                ]
+            },
+            "jsonVersion": {
+                "description": "File format version",
+                "type": [
+                    "string"
+                ]
+            },
+            "defaultPivotX": {
+                "description": "Default X pivot (0 to 1) for new entities",
+                "type": [
+                    "number"
+                ]
+            },
+            "defaultLevelHeight": {
+                "description": "Default new level height",
+                "type": [
+                    "integer"
+                ]
+            },
+            "externalLevels": {
+                "description": "If TRUE, one file will be saved for the project (incl. all its definitions) and one file in a sub-folder for each level.",
+                "type": [
+                    "boolean"
+                ]
+            },
+            "minifyJson": {
+                "description": "If TRUE, the Json is partially minified (no indentation, nor line breaks, default is FALSE)",
+                "type": [
+                    "boolean"
+                ]
+            }
+        },
+        "type": [
+            "object"
+        ]
+    },
+    "otherTypes": {
+        "FieldInstance": {
+            "title": "Field instance",
+            "required": [
+                "__identifier",
+                "__type",
+                "__value",
+                "defUid",
+                "realEditorValues"
+            ],
+            "additionalProperties": false,
+            "properties": {
+                "__type": {
+                    "description": "Type of the field, such as `Int`, `Float`, `Enum(my_enum_name)`, `Bool`, etc.",
+                    "type": [
+                        "string"
+                    ]
+                },
+                "defUid": {
+                    "description": "Reference of the **Field definition** UID",
+                    "type": [
+                        "integer"
+                    ]
+                },
+                "__identifier": {
+                    "description": "Field definition identifier",
+                    "type": [
+                        "string"
+                    ]
+                },
+                "realEditorValues": {
+                    "description": "Editor internal raw values",
+                    "items": {},
+                    "type": [
+                        "array"
+                    ]
+                },
+                "__value": {
+                    "description": "Actual value of the field instance. The value type may vary, depending on `__type` (Integer, Boolean, String etc.)<br/>  It can also be an `Array` of those same types."
+                }
+            },
+            "type": [
+                "object"
+            ]
+        },
+        "EntityInstance": {
+            "title": "Entity instance",
+            "required": [
+                "__grid",
+                "__identifier",
+                "__pivot",
+                "defUid",
+                "fieldInstances",
+                "height",
+                "px",
+                "width"
+            ],
+            "additionalProperties": false,
+            "properties": {
+                "defUid": {
+                    "description": "Reference of the **Entity definition** UID",
+                    "type": [
+                        "integer"
+                    ]
+                },
+                "__identifier": {
+                    "description": "Entity definition identifier",
+                    "type": [
+                        "string"
+                    ]
+                },
+                "__tile": {
+                    "description": "Optional Tile used to display this entity (it could either be the default Entity tile, or some tile provided by a field value, like an Enum).",
+                    "oneOf": [
+                        {
+                            "type": [
+                                "null"
+                            ]
+                        },
+                        {
+                            "$ref": "#/otherTypes/EntityInstanceTile"
+                        }
+                    ]
+                },
+                "px": {
+                    "description": "Pixel coordinates (`[x,y]` format) in current level coordinate space. Don't forget optional layer offsets, if they exist!",
+                    "items": {
+                        "type": [
+                            "integer"
+                        ]
+                    },
+                    "type": [
+                        "array"
+                    ]
+                },
+                "__grid": {
+                    "description": "Grid-based coordinates (`[x,y]` format)",
+                    "items": {
+                        "type": [
+                            "integer"
+                        ]
+                    },
+                    "type": [
+                        "array"
+                    ]
+                },
+                "__pivot": {
+                    "description": "Pivot coordinates  (`[x,y]` format, values are from 0 to 1) of the Entity",
+                    "items": {
+                        "type": [
+                            "number"
+                        ]
+                    },
+                    "type": [
+                        "array"
+                    ]
+                },
+                "fieldInstances": {
+                    "description": "An array of all custom fields and their values.",
+                    "items": {
+                        "$ref": "#/otherTypes/FieldInstance"
+                    },
+                    "type": [
+                        "array"
+                    ]
+                },
+                "height": {
+                    "description": "Entity height in pixels. For non-resizable entities, it will be the same as Entity definition.",
+                    "type": [
+                        "integer"
+                    ]
+                },
+                "width": {
+                    "description": "Entity width in pixels. For non-resizable entities, it will be the same as Entity definition.",
+                    "type": [
+                        "integer"
+                    ]
+                }
+            },
+            "type": [
+                "object"
+            ]
+        },
+        "Definitions": {
+            "description": "If you're writing your own LDtk importer, you should probably just ignore *most* stuff in the `defs` section, as it contains data that are mostly important to the editor. To keep you away from the `defs` section and avoid some unnecessary JSON parsing, important data from definitions is often duplicated in fields prefixed with a double underscore (eg. `__identifier` or `__type`).  The 2 only definition types you might need here are **Tilesets** and **Enums**.",
+            "title": "Definitions",
+            "required": [
+                "entities",
+                "enums",
+                "externalEnums",
+                "layers",
+                "levelFields",
+                "tilesets"
+            ],
+            "additionalProperties": false,
+            "properties": {
+                "tilesets": {
+                    "description": "All tilesets",
+                    "items": {
+                        "$ref": "#/otherTypes/TilesetDef"
+                    },
+                    "type": [
+                        "array"
+                    ]
+                },
+                "layers": {
+                    "description": "All layer definitions",
+                    "items": {
+                        "$ref": "#/otherTypes/LayerDef"
+                    },
+                    "type": [
+                        "array"
+                    ]
+                },
+                "levelFields": {
+                    "description": "All custom fields available to all levels.",
+                    "items": {
+                        "$ref": "#/otherTypes/FieldDef"
+                    },
+                    "type": [
+                        "array"
+                    ]
+                },
+                "enums": {
+                    "description": "All internal enums",
+                    "items": {
+                        "$ref": "#/otherTypes/EnumDef"
+                    },
+                    "type": [
+                        "array"
+                    ]
+                },
+                "entities": {
+                    "description": "All entities definitions, including their custom fields",
+                    "items": {
+                        "$ref": "#/otherTypes/EntityDef"
+                    },
+                    "type": [
+                        "array"
+                    ]
+                },
+                "externalEnums": {
+                    "description": "Note: external enums are exactly the same as `enums`, except they have a `relPath` to point to an external source file.",
+                    "items": {
+                        "$ref": "#/otherTypes/EnumDef"
+                    },
+                    "type": [
+                        "array"
+                    ]
+                }
+            },
+            "type": [
+                "object"
+            ]
+        },
+        "AutoRuleDef": {
+            "description": "This complex section isn't meant to be used by game devs at all, as these rules are completely resolved internally by the editor before any saving. You should just ignore this part.",
+            "title": "Auto-layer rule definition",
+            "required": [
+                "active",
+                "breakOnMatch",
+                "chance",
+                "checker",
+                "flipX",
+                "flipY",
+                "pattern",
+                "perlinActive",
+                "perlinOctaves",
+                "perlinScale",
+                "perlinSeed",
+                "pivotX",
+                "pivotY",
+                "size",
+                "tileIds",
+                "tileMode",
+                "uid",
+                "xModulo",
+                "yModulo"
+            ],
+            "additionalProperties": false,
+            "properties": {
+                "flipX": {
+                    "description": "If TRUE, allow rule to be matched by flipping its pattern horizontally",
+                    "type": [
+                        "boolean"
+                    ]
+                },
+                "pivotX": {
+                    "description": "X pivot of a tile stamp (0-1)",
+                    "type": [
+                        "number"
+                    ]
+                },
+                "perlinActive": {
+                    "description": "If TRUE, enable Perlin filtering to only apply rule on specific random area",
+                    "type": [
+                        "boolean"
+                    ]
+                },
+                "perlinScale": {
+                    "description": "",
+                    "type": [
+                        "number"
+                    ]
+                },
+                "outOfBoundsValue": {
+                    "description": "Default IntGrid value when checking cells outside of level bounds",
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "pattern": {
+                    "description": "Rule pattern (size x size)",
+                    "items": {
+                        "type": [
+                            "integer"
+                        ]
+                    },
+                    "type": [
+                        "array"
+                    ]
+                },
+                "checker": {
+                    "description": "Checker mode Possible values: `None`, `Horizontal`, `Vertical`",
+                    "enum": [
+                        "None",
+                        "Horizontal",
+                        "Vertical"
+                    ]
+                },
+                "perlinOctaves": {
+                    "description": "",
+                    "type": [
+                        "number"
+                    ]
+                },
+                "tileIds": {
+                    "description": "Array of all the tile IDs. They are used randomly or as stamps, based on `tileMode` value.",
+                    "items": {
+                        "type": [
+                            "integer"
+                        ]
+                    },
+                    "type": [
+                        "array"
+                    ]
+                },
+                "xModulo": {
+                    "description": "X cell coord modulo",
+                    "type": [
+                        "integer"
+                    ]
+                },
+                "size": {
+                    "description": "Pattern width & height. Should only be 1,3,5 or 7.",
+                    "type": [
+                        "integer"
+                    ]
+                },
+                "chance": {
+                    "description": "Chances for this rule to be applied (0 to 1)",
+                    "type": [
+                        "number"
+                    ]
+                },
+                "breakOnMatch": {
+                    "description": "When TRUE, the rule will prevent other rules to be applied in the same cell if it matches (TRUE by default).",
+                    "type": [
+                        "boolean"
+                    ]
+                },
+                "uid": {
+                    "description": "Unique Int identifier",
+                    "type": [
+                        "integer"
+                    ]
+                },
+                "perlinSeed": {
+                    "description": "",
+                    "type": [
+                        "number"
+                    ]
+                },
+                "tileMode": {
+                    "description": "Defines how tileIds array is used Possible values: `Single`, `Stamp`",
+                    "enum": [
+                        "Single",
+                        "Stamp"
+                    ]
+                },
+                "flipY": {
+                    "description": "If TRUE, allow rule to be matched by flipping its pattern vertically",
+                    "type": [
+                        "boolean"
+                    ]
+                },
+                "pivotY": {
+                    "description": "Y pivot of a tile stamp (0-1)",
+                    "type": [
+                        "number"
+                    ]
+                },
+                "yModulo": {
+                    "description": "Y cell coord modulo",
+                    "type": [
+                        "integer"
+                    ]
+                },
+                "active": {
+                    "description": "If FALSE, the rule effect isn't applied, and no tiles are generated.",
+                    "type": [
+                        "boolean"
+                    ]
+                }
+            },
+            "type": [
+                "object"
+            ]
+        },
+        "FieldDef": {
+            "description": "This section is mostly only intended for the LDtk editor app itself. You can safely ignore it.",
+            "title": "Field definition",
+            "required": [
+                "__type",
+                "canBeNull",
+                "identifier",
+                "isArray",
+                "type",
+                "uid",
+                "editorAlwaysShow",
+                "editorCutLongValues",
+                "editorDisplayMode",
+                "editorDisplayPos"
+            ],
+            "additionalProperties": false,
+            "properties": {
+                "acceptFileTypes": {
+                    "description": "Optional list of accepted file extensions for FilePath value type. Includes the dot: `.ext`",
+                    "items": {
+                        "type": [
+                            "string"
+                        ]
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "editorAlwaysShow": {
+                    "description": "",
+                    "type": [
+                        "boolean"
+                    ]
+                },
+                "arrayMinLength": {
+                    "description": "Array min length",
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "min": {
+                    "description": "Min limit for value, if applicable",
+                    "type": [
+                        "number",
+                        "null"
+                    ]
+                },
+                "__type": {
+                    "description": "Human readable value type (eg. `Int`, `Float`, `Point`, etc.). If the field is an array, this field will look like `Array<...>` (eg. `Array<Int>`, `Array<Point>` etc.)",
+                    "type": [
+                        "string"
+                    ]
+                },
+                "editorDisplayMode": {
+                    "description": "Possible values: `Hidden`, `ValueOnly`, `NameAndValue`, `EntityTile`, `Points`, `PointStar`, `PointPath`, `PointPathLoop`, `RadiusPx`, `RadiusGrid`",
+                    "enum": [
+                        "Hidden",
+                        "ValueOnly",
+                        "NameAndValue",
+                        "EntityTile",
+                        "Points",
+                        "PointStar",
+                        "PointPath",
+                        "PointPathLoop",
+                        "RadiusPx",
+                        "RadiusGrid"
+                    ]
+                },
+                "canBeNull": {
+                    "description": "TRUE if the value can be null. For arrays, TRUE means it can contain null values (exception: array of Points can't have null values).",
+                    "type": [
+                        "boolean"
+                    ]
+                },
+                "uid": {
+                    "description": "Unique Int identifier",
+                    "type": [
+                        "integer"
+                    ]
+                },
+                "isArray": {
+                    "description": "TRUE if the value is an array of multiple values",
+                    "type": [
+                        "boolean"
+                    ]
+                },
+                "editorDisplayPos": {
+                    "description": "Possible values: `Above`, `Center`, `Beneath`",
+                    "enum": [
+                        "Above",
+                        "Center",
+                        "Beneath"
+                    ]
+                },
+                "textLanguageMode": {
+                    "description": "Possible values: &lt;`null`&gt;, `LangPython`, `LangRuby`, `LangJS`, `LangLua`, `LangC`, `LangHaxe`, `LangMarkdown`, `LangJson`, `LangXml`",
+                    "enum": [
+                        "LangPython",
+                        "LangRuby",
+                        "LangJS",
+                        "LangLua",
+                        "LangC",
+                        "LangHaxe",
+                        "LangMarkdown",
+                        "LangJson",
+                        "LangXml",
+                        null
+                    ]
+                },
+                "max": {
+                    "description": "Max limit for value, if applicable",
+                    "type": [
+                        "number",
+                        "null"
+                    ]
+                },
+                "editorCutLongValues": {
+                    "description": "",
+                    "type": [
+                        "boolean"
+                    ]
+                },
+                "defaultOverride": {
+                    "description": "Default value if selected value is null or invalid."
+                },
+                "regex": {
+                    "description": "Optional regular expression that needs to be matched to accept values. Expected format: `/some_reg_ex/g`, with optional \"i\" flag.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "type": {
+                    "description": "Internal type enum"
+                },
+                "identifier": {
+                    "description": "Unique String identifier",
+                    "type": [
+                        "string"
+                    ]
+                },
+                "arrayMaxLength": {
+                    "description": "Array max length",
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                }
+            },
+            "type": [
+                "object"
+            ]
+        },
+        "EntityDef": {
+            "title": "Entity definition",
+            "required": [
+                "color",
+                "height",
+                "identifier",
+                "pivotX",
+                "pivotY",
+                "uid",
+                "width",
+                "fieldDefs",
+                "fillOpacity",
+                "hollow",
+                "keepAspectRatio",
+                "limitBehavior",
+                "limitScope",
+                "lineOpacity",
+                "maxCount",
+                "renderMode",
+                "resizableX",
+                "resizableY",
+                "showName",
+                "tags",
+                "tileRenderMode"
+            ],
+            "additionalProperties": false,
+            "properties": {
+                "tileId": {
+                    "description": "Tile ID used for optional tile display",
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "showName": {
+                    "description": "Display entity name in editor",
+                    "type": [
+                        "boolean"
+                    ]
+                },
+                "tilesetId": {
+                    "description": "Tileset ID used for optional tile display",
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "limitScope": {
+                    "description": "If TRUE, the maxCount is a \"per world\" limit, if FALSE, it's a \"per level\". Possible values: `PerLayer`, `PerLevel`, `PerWorld`",
+                    "enum": [
+                        "PerLayer",
+                        "PerLevel",
+                        "PerWorld"
+                    ]
+                },
+                "pivotX": {
+                    "description": "Pivot X coordinate (from 0 to 1.0)",
+                    "type": [
+                        "number"
+                    ]
+                },
+                "maxCount": {
+                    "description": "Max instances count",
+                    "type": [
+                        "integer"
+                    ]
+                },
+                "hollow": {
+                    "description": "",
+                    "type": [
+                        "boolean"
+                    ]
+                },
+                "keepAspectRatio": {
+                    "description": "Only applies to entities resizable on both X/Y. If TRUE, the entity instance width/height will keep the same aspect ratio as the definition.",
+                    "type": [
+                        "boolean"
+                    ]
+                },
+                "color": {
+                    "description": "Base entity color",
+                    "type": [
+                        "string"
+                    ]
+                },
+                "fieldDefs": {
+                    "description": "Array of field definitions",
+                    "items": {
+                        "$ref": "#/otherTypes/FieldDef"
+                    },
+                    "type": [
+                        "array"
+                    ]
+                },
+                "tileRenderMode": {
+                    "description": "Possible values: `Cover`, `FitInside`, `Repeat`, `Stretch`",
+                    "enum": [
+                        "Cover",
+                        "FitInside",
+                        "Repeat",
+                        "Stretch"
+                    ]
+                },
+                "limitBehavior": {
+                    "description": "Possible values: `DiscardOldOnes`, `PreventAdding`, `MoveLastOne`",
+                    "enum": [
+                        "DiscardOldOnes",
+                        "PreventAdding",
+                        "MoveLastOne"
+                    ]
+                },
+                "resizableX": {
+                    "description": "If TRUE, the entity instances will be resizable horizontally",
+                    "type": [
+                        "boolean"
+                    ]
+                },
+                "uid": {
+                    "description": "Unique Int identifier",
+                    "type": [
+                        "integer"
+                    ]
+                },
+                "lineOpacity": {
+                    "description": "",
+                    "type": [
+                        "number"
+                    ]
+                },
+                "resizableY": {
+                    "description": "If TRUE, the entity instances will be resizable vertically",
+                    "type": [
+                        "boolean"
+                    ]
+                },
+                "fillOpacity": {
+                    "description": "",
+                    "type": [
+                        "number"
+                    ]
+                },
+                "height": {
+                    "description": "Pixel height",
+                    "type": [
+                        "integer"
+                    ]
+                },
+                "identifier": {
+                    "description": "Unique String identifier",
+                    "type": [
+                        "string"
+                    ]
+                },
+                "pivotY": {
+                    "description": "Pivot Y coordinate (from 0 to 1.0)",
+                    "type": [
+                        "number"
+                    ]
+                },
+                "renderMode": {
+                    "description": "Possible values: `Rectangle`, `Ellipse`, `Tile`, `Cross`",
+                    "enum": [
+                        "Rectangle",
+                        "Ellipse",
+                        "Tile",
+                        "Cross"
+                    ]
+                },
+                "tags": {
+                    "description": "An array of strings that classifies this entity",
+                    "items": {
+                        "type": [
+                            "string"
+                        ]
+                    },
+                    "type": [
+                        "array"
+                    ]
+                },
+                "width": {
+                    "description": "Pixel width",
+                    "type": [
+                        "integer"
+                    ]
+                }
+            },
+            "type": [
+                "object"
+            ]
+        },
+        "AutoLayerRuleGroup": {
+            "title": "Auto-layer rule group",
+            "required": [
+                "active",
+                "collapsed",
+                "isOptional",
+                "name",
+                "rules",
+                "uid"
+            ],
+            "additionalProperties": false,
+            "properties": {
+                "name": {
+                    "description": "",
+                    "type": [
+                        "string"
+                    ]
+                },
+                "collapsed": {
+                    "description": "",
+                    "type": [
+                        "boolean"
+                    ]
+                },
+                "isOptional": {
+                    "description": "",
+                    "type": [
+                        "boolean"
+                    ]
+                },
+                "uid": {
+                    "description": "",
+                    "type": [
+                        "integer"
+                    ]
+                },
+                "active": {
+                    "description": "",
+                    "type": [
+                        "boolean"
+                    ]
+                },
+                "rules": {
+                    "description": "",
+                    "items": {
+                        "$ref": "#/otherTypes/AutoRuleDef"
+                    },
+                    "type": [
+                        "array"
+                    ]
+                }
+            },
+            "type": [
+                "object"
+            ]
+        },
+        "EntityInstanceTile": {
+            "description": "Tile data in an Entity instance",
+            "title": "Entity instance tile",
+            "required": [
+                "srcRect",
+                "tilesetUid"
+            ],
+            "additionalProperties": false,
+            "properties": {
+                "srcRect": {
+                    "description": "An array of 4 Int values that refers to the tile in the tileset image: `[ x, y, width, height ]`",
+                    "items": {
+                        "type": [
+                            "integer"
+                        ]
+                    },
+                    "type": [
+                        "array"
+                    ]
+                },
+                "tilesetUid": {
+                    "description": "Tileset ID",
+                    "type": [
+                        "integer"
+                    ]
+                }
+            },
+            "type": [
+                "object"
+            ]
+        },
+        "IntGridValueInstance": {
+            "description": "IntGrid value instance",
+            "title": "IntGrid value instance",
+            "required": [
+                "coordId",
+                "v"
+            ],
+            "additionalProperties": false,
+            "properties": {
+                "v": {
+                    "description": "IntGrid value",
+                    "type": [
+                        "integer"
+                    ]
+                },
+                "coordId": {
+                    "description": "Coordinate ID in the layer grid",
+                    "type": [
+                        "integer"
+                    ]
+                }
+            },
+            "type": [
+                "object"
+            ]
+        },
+        "NeighbourLevel": {
+            "description": "Nearby level info",
+            "title": "Neighbour level",
+            "required": [
+                "dir",
+                "levelUid"
+            ],
+            "additionalProperties": false,
+            "properties": {
+                "levelUid": {
+                    "description": "",
+                    "type": [
+                        "integer"
+                    ]
+                },
+                "dir": {
+                    "description": "A single lowercase character tipping on the level location (`n`orth, `s`outh, `w`est, `e`ast).",
+                    "type": [
+                        "string"
+                    ]
+                }
+            },
+            "type": [
+                "object"
+            ]
+        },
+        "LayerInstance": {
+            "title": "Layer instance",
+            "required": [
+                "__cHei",
+                "__cWid",
+                "__gridSize",
+                "__identifier",
+                "__opacity",
+                "__pxTotalOffsetX",
+                "__pxTotalOffsetY",
+                "__type",
+                "autoLayerTiles",
+                "entityInstances",
+                "gridTiles",
+                "intGridCsv",
+                "layerDefUid",
+                "levelId",
+                "pxOffsetX",
+                "pxOffsetY",
+                "visible",
+                "optionalRules",
+                "seed"
+            ],
+            "additionalProperties": false,
+            "properties": {
+                "__cHei": {
+                    "description": "Grid-based height",
+                    "type": [
+                        "integer"
+                    ]
+                },
+                "pxOffsetX": {
+                    "description": "X offset in pixels to render this layer, usually 0 (IMPORTANT: this should be added to the `LayerDef` optional offset, see `__pxTotalOffsetX`)",
+                    "type": [
+                        "integer"
+                    ]
+                },
+                "__tilesetRelPath": {
+                    "description": "The relative path to corresponding Tileset, if any.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "levelId": {
+                    "description": "Reference to the UID of the level containing this layer instance",
+                    "type": [
+                        "integer"
+                    ]
+                },
+                "__type": {
+                    "description": "Layer type (possible values: IntGrid, Entities, Tiles or AutoLayer)",
+                    "type": [
+                        "string"
+                    ]
+                },
+                "autoLayerTiles": {
+                    "description": "An array containing all tiles generated by Auto-layer rules. The array is already sorted in display order (ie. 1st tile is beneath 2nd, which is beneath 3rd etc.).<br/><br/>  Note: if multiple tiles are stacked in the same cell as the result of different rules, all tiles behind opaque ones will be discarded.",
+                    "items": {
+                        "$ref": "#/otherTypes/Tile"
+                    },
+                    "type": [
+                        "array"
+                    ]
+                },
+                "optionalRules": {
+                    "description": "An Array containing the UIDs of optional rules that were enabled in this specific layer instance.",
+                    "items": {
+                        "type": [
+                            "integer"
+                        ]
+                    },
+                    "type": [
+                        "array"
+                    ]
+                },
+                "__identifier": {
+                    "description": "Layer definition identifier",
+                    "type": [
+                        "string"
+                    ]
+                },
+                "__gridSize": {
+                    "description": "Grid size",
+                    "type": [
+                        "integer"
+                    ]
+                },
+                "__pxTotalOffsetY": {
+                    "description": "Total layer Y pixel offset, including both instance and definition offsets.",
+                    "type": [
+                        "integer"
+                    ]
+                },
+                "intGridCsv": {
+                    "description": "A list of all values in the IntGrid layer, stored from left to right, and top to bottom (ie. first row from left to right, followed by second row, etc). `0` means \"empty cell\" and IntGrid values start at 1. This array size is `__cWid` x `__cHei` cells.",
+                    "items": {
+                        "type": [
+                            "integer"
+                        ]
+                    },
+                    "type": [
+                        "array"
+                    ]
+                },
+                "overrideTilesetUid": {
+                    "description": "This layer can use another tileset by overriding the tileset UID here.",
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "visible": {
+                    "description": "Layer instance visibility",
+                    "type": [
+                        "boolean"
+                    ]
+                },
+                "entityInstances": {
+                    "description": "",
+                    "items": {
+                        "$ref": "#/otherTypes/EntityInstance"
+                    },
+                    "type": [
+                        "array"
+                    ]
+                },
+                "__opacity": {
+                    "description": "Layer opacity as Float [0-1]",
+                    "type": [
+                        "number"
+                    ]
+                },
+                "seed": {
+                    "description": "Random seed used for Auto-Layers rendering",
+                    "type": [
+                        "integer"
+                    ]
+                },
+                "layerDefUid": {
+                    "description": "Reference the Layer definition UID",
+                    "type": [
+                        "integer"
+                    ]
+                },
+                "__pxTotalOffsetX": {
+                    "description": "Total layer X pixel offset, including both instance and definition offsets.",
+                    "type": [
+                        "integer"
+                    ]
+                },
+                "__cWid": {
+                    "description": "Grid-based width",
+                    "type": [
+                        "integer"
+                    ]
+                },
+                "pxOffsetY": {
+                    "description": "Y offset in pixels to render this layer, usually 0 (IMPORTANT: this should be added to the `LayerDef` optional offset, see `__pxTotalOffsetY`)",
+                    "type": [
+                        "integer"
+                    ]
+                },
+                "__tilesetDefUid": {
+                    "description": "The definition UID of corresponding Tileset, if any.",
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "gridTiles": {
+                    "description": "",
+                    "items": {
+                        "$ref": "#/otherTypes/Tile"
+                    },
+                    "type": [
+                        "array"
+                    ]
+                },
+                "intGrid": {
+                    "description": "**WARNING**: this deprecated value will be *removed* completely on version 0.10.0+  Replaced by: `intGridCsv`",
+                    "items": {
+                        "$ref": "#/otherTypes/IntGridValueInstance"
+                    },
+                    "type": [
+                        "array"
+                    ]
+                }
+            },
+            "type": [
+                "object"
+            ]
+        },
+        "TilesetDef": {
+            "description": "The `Tileset` definition is the most important part among project definitions. It contains some extra informations about each integrated tileset. If you only had to parse one definition section, that would be the one.",
+            "title": "Tileset definition",
+            "required": [
+                "__cHei",
+                "__cWid",
+                "customData",
+                "enumTags",
+                "identifier",
+                "padding",
+                "pxHei",
+                "pxWid",
+                "relPath",
+                "spacing",
+                "tileGridSize",
+                "uid",
+                "savedSelections"
+            ],
+            "additionalProperties": false,
+            "properties": {
+                "cachedPixelData": {
+                    "description": "The following data is used internally for various optimizations. It's always synced with source image changes.",
+                    "type": [
+                        "object",
+                        "null"
+                    ]
+                },
+                "__cHei": {
+                    "description": "Grid-based height",
+                    "type": [
+                        "integer"
+                    ]
+                },
+                "pxHei": {
+                    "description": "Image height in pixels",
+                    "type": [
+                        "integer"
+                    ]
+                },
+                "customData": {
+                    "description": "An array of custom tile metadata",
+                    "items": {
+                        "type": [
+                            "object"
+                        ]
+                    },
+                    "type": [
+                        "array"
+                    ]
+                },
+                "tagsSourceEnumUid": {
+                    "description": "Optional Enum definition UID used for this tileset meta-data",
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "uid": {
+                    "description": "Unique Intidentifier",
+                    "type": [
+                        "integer"
+                    ]
+                },
+                "padding": {
+                    "description": "Distance in pixels from image borders",
+                    "type": [
+                        "integer"
+                    ]
+                },
+                "enumTags": {
+                    "description": "Tileset tags using Enum values specified by `tagsSourceEnumId`. This array contains 1 element per Enum value, which contains an array of all Tile IDs that are tagged with it.",
+                    "items": {
+                        "type": [
+                            "object"
+                        ]
+                    },
+                    "type": [
+                        "array"
+                    ]
+                },
+                "pxWid": {
+                    "description": "Image width in pixels",
+                    "type": [
+                        "integer"
+                    ]
+                },
+                "__cWid": {
+                    "description": "Grid-based width",
+                    "type": [
+                        "integer"
+                    ]
+                },
+                "spacing": {
+                    "description": "Space in pixels between all tiles",
+                    "type": [
+                        "integer"
+                    ]
+                },
+                "identifier": {
+                    "description": "Unique String identifier",
+                    "type": [
+                        "string"
+                    ]
+                },
+                "savedSelections": {
+                    "description": "Array of group of tiles selections, only meant to be used in the editor",
+                    "items": {
+                        "type": [
+                            "object"
+                        ]
+                    },
+                    "type": [
+                        "array"
+                    ]
+                },
+                "relPath": {
+                    "description": "Path to the source file, relative to the current project JSON file",
+                    "type": [
+                        "string"
+                    ]
+                },
+                "tileGridSize": {
+                    "description": "",
+                    "type": [
+                        "integer"
+                    ]
+                }
+            },
+            "type": [
+                "object"
+            ]
+        },
+        "EnumDefValues": {
+            "title": "Enum value definition",
+            "required": [
+                "color",
+                "id"
+            ],
+            "additionalProperties": false,
+            "properties": {
+                "tileId": {
+                    "description": "The optional ID of the tile",
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "color": {
+                    "description": "Optional color",
+                    "type": [
+                        "integer"
+                    ]
+                },
+                "id": {
+                    "description": "Enum value",
+                    "type": [
+                        "string"
+                    ]
+                },
+                "__tileSrcRect": {
+                    "description": "An array of 4 Int values that refers to the tile in the tileset image: `[ x, y, width, height ]`",
+                    "items": {
+                        "type": [
+                            "integer"
+                        ]
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                }
+            },
+            "type": [
+                "object"
+            ]
+        },
+        "Tile": {
+            "description": "This structure represents a single tile from a given Tileset.",
+            "title": "Tile instance",
+            "required": [
+                "f",
+                "px",
+                "src",
+                "t",
+                "d"
+            ],
+            "additionalProperties": false,
+            "properties": {
+                "t": {
+                    "description": "The *Tile ID* in the corresponding tileset.",
+                    "type": [
+                        "integer"
+                    ]
+                },
+                "d": {
+                    "description": "Internal data used by the editor.<br/>  For auto-layer tiles: `[ruleId, coordId]`.<br/>  For tile-layer tiles: `[coordId]`.",
+                    "items": {
+                        "type": [
+                            "integer"
+                        ]
+                    },
+                    "type": [
+                        "array"
+                    ]
+                },
+                "px": {
+                    "description": "Pixel coordinates of the tile in the **layer** (`[x,y]` format). Don't forget optional layer offsets, if they exist!",
+                    "items": {
+                        "type": [
+                            "integer"
+                        ]
+                    },
+                    "type": [
+                        "array"
+                    ]
+                },
+                "f": {
+                    "description": "\"Flip bits\", a 2-bits integer to represent the mirror transformations of the tile.<br/>   - Bit 0 = X flip<br/>   - Bit 1 = Y flip<br/>   Examples: f=0 (no flip), f=1 (X flip only), f=2 (Y flip only), f=3 (both flips)",
+                    "type": [
+                        "integer"
+                    ]
+                },
+                "src": {
+                    "description": "Pixel coordinates of the tile in the **tileset** (`[x,y]` format)",
+                    "items": {
+                        "type": [
+                            "integer"
+                        ]
+                    },
+                    "type": [
+                        "array"
+                    ]
+                }
+            },
+            "type": [
+                "object"
+            ]
+        },
+        "LayerDef": {
+            "title": "Layer definition",
+            "required": [
+                "__type",
+                "displayOpacity",
+                "gridSize",
+                "identifier",
+                "intGridValues",
+                "pxOffsetX",
+                "pxOffsetY",
+                "uid",
+                "autoRuleGroups",
+                "excludedTags",
+                "requiredTags",
+                "tilePivotX",
+                "tilePivotY",
+                "type"
+            ],
+            "additionalProperties": false,
+            "properties": {
+                "pxOffsetX": {
+                    "description": "X offset of the layer, in pixels (IMPORTANT: this should be added to the `LayerInstance` optional offset)",
+                    "type": [
+                        "integer"
+                    ]
+                },
+                "tilePivotX": {
+                    "description": "If the tiles are smaller or larger than the layer grid, the pivot value will be used to position the tile relatively its grid cell.",
+                    "type": [
+                        "number"
+                    ]
+                },
+                "displayOpacity": {
+                    "description": "Opacity of the layer (0 to 1.0)",
+                    "type": [
+                        "number"
+                    ]
+                },
+                "__type": {
+                    "description": "Type of the layer (*IntGrid, Entities, Tiles or AutoLayer*)",
+                    "type": [
+                        "string"
+                    ]
+                },
+                "tilesetDefUid": {
+                    "description": "Reference to the Tileset UID being used by this Tile layer. WARNING: some layer *instances* might use a different tileset. So most of the time, you should probably use the `__tilesetDefUid` value from layer instances.",
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "autoSourceLayerDefUid": {
+                    "description": "",
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "autoTilesetDefUid": {
+                    "description": "Reference to the Tileset UID being used by this auto-layer rules. WARNING: some layer *instances* might use a different tileset. So most of the time, you should probably use the `__tilesetDefUid` value from layer instances.",
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "uid": {
+                    "description": "Unique Int identifier",
+                    "type": [
+                        "integer"
+                    ]
+                },
+                "excludedTags": {
+                    "description": "An array of tags to forbid some Entities in this layer",
+                    "items": {
+                        "type": [
+                            "string"
+                        ]
+                    },
+                    "type": [
+                        "array"
+                    ]
+                },
+                "intGridValues": {
+                    "description": "An array that defines extra optional info for each IntGrid value. The array is sorted using value (ascending).",
+                    "items": {
+                        "$ref": "#/otherTypes/IntGridValueDef"
+                    },
+                    "type": [
+                        "array"
+                    ]
+                },
+                "autoRuleGroups": {
+                    "description": "Contains all the auto-layer rule definitions.",
+                    "items": {
+                        "$ref": "#/otherTypes/AutoLayerRuleGroup"
+                    },
+                    "type": [
+                        "array"
+                    ]
+                },
+                "type": {
+                    "description": "Type of the layer as Haxe Enum Possible values: `IntGrid`, `Entities`, `Tiles`, `AutoLayer`",
+                    "enum": [
+                        "IntGrid",
+                        "Entities",
+                        "Tiles",
+                        "AutoLayer"
+                    ]
+                },
+                "identifier": {
+                    "description": "Unique String identifier",
+                    "type": [
+                        "string"
+                    ]
+                },
+                "requiredTags": {
+                    "description": "An array of tags to filter Entities that can be added to this layer",
+                    "items": {
+                        "type": [
+                            "string"
+                        ]
+                    },
+                    "type": [
+                        "array"
+                    ]
+                },
+                "pxOffsetY": {
+                    "description": "Y offset of the layer, in pixels (IMPORTANT: this should be added to the `LayerInstance` optional offset)",
+                    "type": [
+                        "integer"
+                    ]
+                },
+                "tilePivotY": {
+                    "description": "If the tiles are smaller or larger than the layer grid, the pivot value will be used to position the tile relatively its grid cell.",
+                    "type": [
+                        "number"
+                    ]
+                },
+                "gridSize": {
+                    "description": "Width and height of the grid in pixels",
+                    "type": [
+                        "integer"
+                    ]
+                }
+            },
+            "type": [
+                "object"
+            ]
+        },
+        "LevelBgPosInfos": {
+            "description": "Level background image position info",
+            "title": "Level background position",
+            "required": [
+                "cropRect",
+                "scale",
+                "topLeftPx"
+            ],
+            "additionalProperties": false,
+            "properties": {
+                "cropRect": {
+                    "description": "An array of 4 float values describing the cropped sub-rectangle of the displayed background image. This cropping happens when original is larger than the level bounds. Array format: `[ cropX, cropY, cropWidth, cropHeight ]`",
+                    "items": {
+                        "type": [
+                            "number"
+                        ]
+                    },
+                    "type": [
+                        "array"
+                    ]
+                },
+                "scale": {
+                    "description": "An array containing the `[scaleX,scaleY]` values of the **cropped** background image, depending on `bgPos` option.",
+                    "items": {
+                        "type": [
+                            "number"
+                        ]
+                    },
+                    "type": [
+                        "array"
+                    ]
+                },
+                "topLeftPx": {
+                    "description": "An array containing the `[x,y]` pixel coordinates of the top-left corner of the **cropped** background image, depending on `bgPos` option.",
+                    "items": {
+                        "type": [
+                            "integer"
+                        ]
+                    },
+                    "type": [
+                        "array"
+                    ]
+                }
+            },
+            "type": [
+                "object"
+            ]
+        },
+        "Level": {
+            "description": "This section contains all the level data. It can be found in 2 distinct forms, depending on Project current settings:  - If \"*Separate level files*\" is **disabled** (default): full level data is *embedded* inside the main Project JSON file, - If \"*Separate level files*\" is **enabled**: level data is stored in *separate* standalone `.ldtkl` files (one per level). In this case, the main Project JSON file will still contain most level data, except heavy sections, like the `layerInstances` array (which will be null). The `externalRelPath` string points to the `ldtkl` file.  A `ldtkl` file is just a JSON file containing exactly what is described below.",
+            "title": "Level",
+            "required": [
+                "__bgColor",
+                "__neighbours",
+                "fieldInstances",
+                "identifier",
+                "pxHei",
+                "pxWid",
+                "uid",
+                "worldX",
+                "worldY",
+                "bgPivotX",
+                "bgPivotY",
+                "useAutoIdentifier"
+            ],
+            "additionalProperties": false,
+            "properties": {
+                "__neighbours": {
+                    "description": "An array listing all other levels touching this one on the world map. In \"linear\" world layouts, this array is populated with previous/next levels in array, and `dir` depends on the linear horizontal/vertical layout.",
+                    "items": {
+                        "$ref": "#/otherTypes/NeighbourLevel"
+                    },
+                    "type": [
+                        "array"
+                    ]
+                },
+                "__bgColor": {
+                    "description": "Background color of the level (same as `bgColor`, except the default value is automatically used here if its value is `null`)",
+                    "type": [
+                        "string"
+                    ]
+                },
+                "worldX": {
+                    "description": "World X coordinate in pixels",
+                    "type": [
+                        "integer"
+                    ]
+                },
+                "externalRelPath": {
+                    "description": "This value is not null if the project option \"*Save levels separately*\" is enabled. In this case, this **relative** path points to the level Json file.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "useAutoIdentifier": {
+                    "description": "If TRUE, the level identifier will always automatically use the naming pattern as defined in `Project.levelNamePattern`. Becomes FALSE if the identifier is manually modified by user.",
+                    "type": [
+                        "boolean"
+                    ]
+                },
+                "bgColor": {
+                    "description": "Background color of the level. If `null`, the project `defaultLevelBgColor` should be used.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "bgPos": {
+                    "description": "An enum defining the way the background image (if any) is positioned on the level. See `__bgPos` for resulting position info. Possible values: &lt;`null`&gt;, `Unscaled`, `Contain`, `Cover`, `CoverDirty`",
+                    "enum": [
+                        "Unscaled",
+                        "Contain",
+                        "Cover",
+                        "CoverDirty",
+                        null
+                    ]
+                },
+                "pxHei": {
+                    "description": "Height of the level in pixels",
+                    "type": [
+                        "integer"
+                    ]
+                },
+                "worldY": {
+                    "description": "World Y coordinate in pixels",
+                    "type": [
+                        "integer"
+                    ]
+                },
+                "__bgPos": {
+                    "description": "Position informations of the background image, if there is one.",
+                    "oneOf": [
+                        {
+                            "type": [
+                                "null"
+                            ]
+                        },
+                        {
+                            "$ref": "#/otherTypes/LevelBgPosInfos"
+                        }
+                    ]
+                },
+                "uid": {
+                    "description": "Unique Int identifier",
+                    "type": [
+                        "integer"
+                    ]
+                },
+                "fieldInstances": {
+                    "description": "An array containing this level custom field values.",
+                    "items": {
+                        "$ref": "#/otherTypes/FieldInstance"
+                    },
+                    "type": [
+                        "array"
+                    ]
+                },
+                "pxWid": {
+                    "description": "Width of the level in pixels",
+                    "type": [
+                        "integer"
+                    ]
+                },
+                "identifier": {
+                    "description": "Unique String identifier",
+                    "type": [
+                        "string"
+                    ]
+                },
+                "bgPivotY": {
+                    "description": "Background image Y pivot (0-1)",
+                    "type": [
+                        "number"
+                    ]
+                },
+                "bgPivotX": {
+                    "description": "Background image X pivot (0-1)",
+                    "type": [
+                        "number"
+                    ]
+                },
+                "layerInstances": {
+                    "description": "An array containing all Layer instances. **IMPORTANT**: if the project option \"*Save levels separately*\" is enabled, this field will be `null`.<br/>  This array is **sorted in display order**: the 1st layer is the top-most and the last is behind.",
+                    "items": {
+                        "$ref": "#/otherTypes/LayerInstance"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "bgRelPath": {
+                    "description": "The *optional* relative path to the level background image.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            },
+            "type": [
+                "object"
+            ]
+        },
+        "EnumDef": {
+            "title": "Enum definition",
+            "required": [
+                "identifier",
+                "uid",
+                "values"
+            ],
+            "additionalProperties": false,
+            "properties": {
+                "externalFileChecksum": {
+                    "description": "",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "externalRelPath": {
+                    "description": "Relative path to the external file providing this Enum",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "uid": {
+                    "description": "Unique Int identifier",
+                    "type": [
+                        "integer"
+                    ]
+                },
+                "values": {
+                    "description": "All possible enum values, with their optional Tile infos.",
+                    "items": {
+                        "$ref": "#/otherTypes/EnumDefValues"
+                    },
+                    "type": [
+                        "array"
+                    ]
+                },
+                "iconTilesetUid": {
+                    "description": "Tileset UID if provided",
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "identifier": {
+                    "description": "Unique String identifier",
+                    "type": [
+                        "string"
+                    ]
+                }
+            },
+            "type": [
+                "object"
+            ]
+        },
+        "IntGridValueDef": {
+            "description": "IntGrid value definition",
+            "title": "IntGrid value definition",
+            "required": [
+                "color",
+                "value"
+            ],
+            "additionalProperties": false,
+            "properties": {
+                "color": {
+                    "description": "",
+                    "type": [
+                        "string"
+                    ]
+                },
+                "identifier": {
+                    "description": "Unique String identifier",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "value": {
+                    "description": "The IntGrid value itself",
+                    "type": [
+                        "integer"
+                    ]
+                }
+            },
+            "type": [
+                "object"
+            ]
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,6 +58,7 @@
 //!
 //! This crate currently has the schema for the following versions of LDtk built-in:
 //!
+//! - `v0.9.3`
 //! - `v0.8.1` ( patched, see note below )
 //! - `v0.7.0`
 //!


### PR DESCRIPTION
Hey there, 

Brilliant work on that crate. I took it upon myself to update this to use the latest version of LDtk (0.9.3). I'm not really sure if that is exactly necessary since compiling this with the `download-schema` feature will download the latest version, but I went ahead and did it anyway.

Cloned `bevy_retro` on my local setup, changed the dependency to my fork, then tested the `ldtk_map` example, everything seems to work. Tested live-reloading the map with the latest LDtk version, works fine as well. 

Feel free to merge or not :) 

Note: If you want to upload this to `crates.io`, you'll need to update the version of the crate. I didnt do it myself as I dont know your policy regarding semver.