### PR TITLE
Rename Feature Flags

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
     "rust-analyzer.cargo.features": [
-        "ldtk-v0.9.3"
+        "ldtk-v0-9-3"
     ]
 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,9 +20,9 @@ categories = [
 default = []
 
 # Specify one of these features to use a crate built-in schema
-'ldtk-v0.7.0' = ["local-schema"]
-'ldtk-v0.8.1' = ["local-schema"]
-'ldtk-v0.9.3' = ["local-schema"]
+'ldtk-v0-7-0' = ["local-schema"]
+'ldtk-v0-8-1' = ["local-schema"]
+'ldtk-v0-9-3' = ["local-schema"]
 
 # Or specify this feature to download the schema automatically from GitHub
 download-schema = ["isahc"]
@@ -42,4 +42,4 @@ serde_json = "1.0.61"
 isahc = { version = "1.0.3", features = ["json"], optional = true }
 
 [package.metadata.docs.rs]
-features = ["ldtk-v0.9.3"]
+features = ["ldtk-v--9-3"]

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ format using [`serde`].
 
 ```toml
 # Note: We must specify the version of LDtk we want to support in a feature flag
-ldtk = { version = "0.4.0", features = ["ldtk-v0.9.3"] }
+ldtk = { version = "0.4.0", features = ["ldtk-v0-9-3"] }
 ```
 
 **`main.rs`:**
@@ -77,6 +77,10 @@ This crate currently has the schema for the following versions of LDtk built-in:
 - `v0.9.3`
 - `v0.8.1` ( patched, see note below )
 - `v0.7.0`
+
+The format of the feature flags for specific versions is like this: `ldtk-v0-9-3`. Note that the
+periods in the version have been replaced with dashes to be conformat with cargo's feature
+naming conventions.
 
 > **Note:** In version 0.8.1 there was a field that was marked as non-null in the JSON schema,
 > but in one of the LDtk sample maps the field was null. We patched the JSON schema to make the

--- a/build.rs
+++ b/build.rs
@@ -145,13 +145,13 @@ fn main() {
     // flags are specified, even though that shouldn't be done, the latest one will take precedence.
     //
 
-    #[cfg(all(not(feature = "download-schema"), feature = "ldtk-v0.7.0"))]
+    #[cfg(all(not(feature = "download-schema"), feature = "ldtk-v0-7-0"))]
     let ldtk_version = "v0.7.0";
 
-    #[cfg(all(not(feature = "download-schema"), feature = "ldtk-v0.8.1"))]
+    #[cfg(all(not(feature = "download-schema"), feature = "ldtk-v0-8-1"))]
     let ldtk_version = "v0.8.1";
 
-    #[cfg(all(not(feature = "download-schema"), feature = "ldtk-v0.9.3"))]
+    #[cfg(all(not(feature = "download-schema"), feature = "ldtk-v0-9-3"))]
     let ldtk_version = "v0.9.3";
 
     #[cfg(not(feature = "download-schema"))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@
 //!
 //! ```toml
 //! # Note: We must specify the version of LDtk we want to support in a feature flag
-//! ldtk = { version = "0.4.0", features = ["ldtk-v0.9.3"] }
+//! ldtk = { version = "0.4.0", features = ["ldtk-v0-9-3"] }
 //! ```
 //!
 //! **`main.rs`:**
@@ -71,6 +71,10 @@
 //! - `v0.9.3`
 //! - `v0.8.1` ( patched, see note below )
 //! - `v0.7.0`
+//!
+//! The format of the feature flags for specific versions is like this: `ldtk-v0-9-3`. Note that the
+//! periods in the version have been replaced with dashes to be conformat with cargo's feature
+//! naming conventions.
 //!
 //! > **Note:** In version 0.8.1 there was a field that was marked as non-null in the JSON schema,
 //! > but in one of the LDtk sample maps the field was null. We patched the JSON schema to make the


### PR DESCRIPTION
Apparently we can't use periods in feature names.